### PR TITLE
Fix Url input when sys.argv > 2

### DIFF
--- a/PSA.py
+++ b/PSA.py
@@ -9,6 +9,7 @@ if __name__ == "__main__":
     MODE = PSAMode.Full
 
     if len(sys.argv) > 2:
+        url = sys.argv[1]
         if sys.argv[2].lower() == "latest":
             MODE = PSAMode.Latest
         else:


### PR DESCRIPTION
It doesn't gives the input to url if the first condition of **sys.argv > 2** goes true!

```py
Traceback (most recent call last):
  File "PSA.py", line 23, in <module>
    entries, metadata = parse_page(url, SCRAPER, MODE)
NameError: name 'url' is not defined
```