### PR TITLE
Parse url with urllib to prevent some links fail

### DIFF
--- a/PSA.py
+++ b/PSA.py
@@ -1,4 +1,4 @@
-import cfscrape, sys, os
+import cfscrape, sys, os, urllib
 from psaripper.pageparser import parse_page
 from psaripper.metadata import Hosters
 from psaripper.PSAMedia import PSAMode
@@ -29,6 +29,7 @@ if __name__ == "__main__":
 
     else:
         url = input("Enter a PSA url - ")
+        urllib.parse.quote(url)
         MODE = mode_parse(input("Enter download mode (latest/full/1080p/720p) - "))
 
     entries, metadata = parse_page(url, SCRAPER, MODE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4
 cfscrape
 lxml
+urllib3


### PR DESCRIPTION
Without parsing links like `https://psarips.xyz/tv-show/rupauls-drag-race-all-stars/` containing dashes were failing to fetch links from the website and gave an empty log file